### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "dayjs": "^1.11.13",
     "js-cookie": "^3.0.5",
     "vue": "^3.5.20",
-    "vue-i18n": "^11.1.11"
+    "vue-i18n": "^11.1.11",
+    "he": "^1.2.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <script setup>
   import { ref, computed, onMounted } from 'vue'
   import { useI18n } from 'vue-i18n'
+  import { decode } from 'he'
   import ApiForm from '@/components/api/ApiForm.vue'
   import LanguageSelector from '@/components/i18n/LanguageSelector.vue'
 
@@ -21,9 +22,7 @@
 
   // 数値文字参照変換
   function decodeHtmlEntities(str) {
-    const txt = document.createElement('textarea')
-    txt.innerHTML = str
-    return txt.value
+    return decode(str)
   }
 
   // プレーンテキストに変換して表示


### PR DESCRIPTION
Potential fix for [https://github.com/tunakaniri/zzz-gacha-history/security/code-scanning/2](https://github.com/tunakaniri/zzz-gacha-history/security/code-scanning/2)

In general, to fix “DOM text reinterpreted as HTML” issues, avoid passing untrusted strings through DOM APIs that parse them as HTML (`innerHTML`, jQuery `$()`, `document.write`, etc.) just to extract or transform their text. Instead, use pure string-based decoding/escaping functions, or DOM APIs that treat input strictly as text (`textContent`, `value`, `createTextNode`) without re-parsing it as HTML.

For this specific code, the vulnerable pattern is in `decodeHtmlEntities`:

```js
function decodeHtmlEntities(str) {
  const txt = document.createElement('textarea')
  txt.innerHTML = str
  return txt.value
}
```

Assigning `str` to `innerHTML` is what causes HTML interpretation. We can preserve the same numeric-entity-decoding behavior without ever reinterpreting `str` as HTML by using a library that safely decodes HTML entities as pure strings. A well-known library for that is `he` (HTML entities), which provides `he.decode`. The best low-impact fix is:

- Import `decode` from the `he` package at the top of this script.
- Replace the body of `decodeHtmlEntities` to simply return `decode(str)` instead of using a `<textarea>` and `innerHTML`.

This keeps the `decodeHtmlEntities` API unchanged, so the rest of the component behavior remains the same, but it removes any HTML parsing from the decoding process. It also makes future use of `decodeHtmlEntities` safer even if untrusted input is passed to it.

Concretely, in `src/App.vue`:

1. Add `import { decode } from 'he'` alongside the existing imports.
2. Change `decodeHtmlEntities` to:

   ```js
   function decodeHtmlEntities(str) {
     return decode(str)
   }
   ```

No other changes are needed in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
